### PR TITLE
Add .git-blame-ignore-revs for the formatting commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Commits listed here are skipped by `git blame` so that repo-wide formatting
+# changes don't obscure the authorship of the surrounding code.
+#
+# GitHub's blame view honours this file automatically.
+# For local git, opt in once per clone:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Append future repo-wide formatting commits below.
+
+# Fix formatting (rustfmt pass over the tree after PR #25)
+f629512ea383a0fbe703ecf4a941209a8efb02bd


### PR DESCRIPTION
Adds a `.git-blame-ignore-revs` listing f629512 ("Fix formatting"), which was a pure rustfmt pass. The ignore refs ensures that a line blame refers to an actual relevant commit in the future.
